### PR TITLE
Title update

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Learn Theme for Hugo"
+title: "Pharmaverse Examples"
 ---
 
 # pharmaverse examples


### PR DESCRIPTION
So that in a social link, it says "Pharmaverse Examples" instead of "Learn Theme for Hugo"